### PR TITLE
Feature/sam2 refresh api

### DIFF
--- a/CHICCHIC/src/apis/auth.ts
+++ b/CHICCHIC/src/apis/auth.ts
@@ -35,3 +35,12 @@ export const putProfileImage = (formData: FormData) => {
     headers: { "Content-Type": "multipart/form-data" },
   });
 };
+
+export const deleteProfileImage = () => {
+  return axiosInstance.delete<{
+    isSuccess: boolean;
+    code: string;
+    message: string;
+    result: string;
+  }>("/member/profile-image");
+};

--- a/CHICCHIC/src/apis/auth.ts
+++ b/CHICCHIC/src/apis/auth.ts
@@ -28,7 +28,6 @@ export const deleteUserInfo = () => {
 
 export const getProfileImage = () => {
   return axiosInstance.get<{ result: string }>("/member/profile-image");
-  // result: string (URL)
 };
 
 export const putProfileImage = (formData: FormData) => {

--- a/CHICCHIC/src/apis/axiosInstance.ts
+++ b/CHICCHIC/src/apis/axiosInstance.ts
@@ -1,27 +1,18 @@
 import axios from "axios";
-import { getAccessToken } from "../utils/authStorage";
-//import axios { type InternalAxiosRequestConfig } from "axios";
+import { getAccessToken, getRefreshToken, setAccessToken, setRefreshToken, clearAuthTokens } from "../utils/authStorage";
+import { useAuthStore } from "../store/useAuthStore";
 
-// retry 플래그
-// interface RetryableAxiosRequestConfig extends InternalAxiosRequestConfig {
-//   _retry?: boolean;
-// }
-
-// 전역 변수로 refresh 요청의 Promise를 저장해서 중복 요청을 방지
-//let refreshPromise: Promise<string> | null = null;
-
-// 모든 요청에 백엔드 주소 붙여줌
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_SERVER_API_URL, // env 파일
+  baseURL: import.meta.env.VITE_SERVER_API_URL,
   withCredentials: true,
 });
 
-// 모든 요청 전에 accessToken을 Authorization 헤더에 추가
 axiosInstance.interceptors.request.use(
   (config) => {
     const noAuthPaths = [
       "/api/v1/auth/login",
       "/api/v1/auth/signup",
+      "/member/reissue",
       // 필요시 소셜 로그인 등
     ];
     if (noAuthPaths.some((path) => config.url?.includes(path))) {
@@ -36,4 +27,66 @@ axiosInstance.interceptors.request.use(
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+let isRefreshing = false;
+let refreshPromise: Promise<any> | null = null;
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(error);
+    }
+
+    originalRequest._retry = true;
+    const refreshToken = getRefreshToken();
+
+    if (!refreshToken) {
+      clearAuthTokens();
+      return Promise.reject(error);
+    }
+
+    // 이미 재발급 중이면 해당 Promise를 기다림
+    if (isRefreshing) {
+      return refreshPromise?.then(() => axiosInstance(originalRequest));
+    }
+
+    isRefreshing = true;
+    useAuthStore.getState().setIsRefreshing(true);
+    console.log("재발급 시작");
+
+    refreshPromise = axios.post(
+      `${import.meta.env.VITE_SERVER_API_URL}/member/reissue`,
+      { refreshToken }
+    ).then((res) => {
+      console.log("재발급 응답:", res.data);
+      const { accessToken: newAT, refreshToken: newRT } = res.data.result ?? res.data;
+      if (!newAT) throw new Error("No accessToken from reissue");
+
+      setAccessToken(newAT);
+      if (newRT) setRefreshToken(newRT);
+      console.log("재발급 성공, 원요청 재시도");
+      return res;
+    }).catch((e) => {
+      console.error("재발급 실패", e);
+      clearAuthTokens();
+      throw e;
+    }).finally(() => {
+      isRefreshing = false;
+      refreshPromise = null;
+      useAuthStore.getState().setIsRefreshing(false);
+      console.log("재발급 끝");
+    });
+
+    try {
+      await refreshPromise;
+      originalRequest.headers.Authorization = `Bearer ${getAccessToken()}`;
+      return axiosInstance(originalRequest);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
 );

--- a/CHICCHIC/src/apis/products.ts
+++ b/CHICCHIC/src/apis/products.ts
@@ -4,6 +4,7 @@ import type {
   ResponseProductReviewDto,
   ResponseScrapDto,
   ResponseUpdateReviewDto,
+  ResponseScrapListDto,
 } from "../types/perfumes";
 import type {
   ResponseProductCategoryDto,
@@ -30,8 +31,6 @@ export const getPerfumeCategory = async (
     throw e;
   }
 };
-
-// 향수 카테고리 조회 (인기순, 낮은 가격순, 높은 가격순, 누적판매순, 리뷰많은순, 평점높은순)
 
 // 상품 상세정보 조회
 export const getPerfumeDetail = async (
@@ -121,6 +120,19 @@ export const updateProductReview = async (
     return data;
   } catch (e) {
     console.error("수정 요청 실패", e);
+    throw e;
+  }
+};
+
+// 스크랩 목록 조회
+export const getScrapList = async (): Promise<ResponseScrapListDto> => {
+  try {
+    console.log("스크랩 목록 조회 요청");
+    const { data } = await axiosInstance.get<ResponseScrapListDto>("/scrap");
+    console.log("스크랩 목록 조회 성공", data);
+    return data;
+  } catch (e) {
+    console.error("스크랩 목록 조회 실패", e);
     throw e;
   }
 };

--- a/CHICCHIC/src/components/PersonalPerfumeTest/perfume-grid.tsx
+++ b/CHICCHIC/src/components/PersonalPerfumeTest/perfume-grid.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { PerfumeCard } from './perfume-card';
 import type { Perfume } from '../../types/perfumes';
+import { axiosInstance } from '../../apis/axiosInstance';
 
 // API 응답에 대한 타입 정의
 interface ApiPerfume {
@@ -20,17 +21,10 @@ export function PerfumeGrid() {
   useEffect(() => {
     const fetchPopularPerfumes = async () => {
       try {
-        const response = await fetch(
-          'https://be-chicchicenvironments.up.railway.app/home/popular-products',
-        );
-        if (!response.ok) {
-          console.error('API 요청 실패:', response);
-          throw new Error(`향수 정보를 불러오는데 실패했습니다. (상태 코드: ${response.status})`);
-        }
-        const data = await response.json();
+        const response = await axiosInstance.get('/api/v1/perfumes/popular');
 
         // API 응답이 객체이고 result 속성에 배열이 담겨있습니다.
-        const perfumeList: ApiPerfume[] = data.result;
+        const perfumeList: ApiPerfume[] = response.data.result;
 
         if (!Array.isArray(perfumeList)) {
           throw new Error('API 응답 형식이 올바르지 않습니다 (배열이 아님).');

--- a/CHICCHIC/src/components/PersonalPerfumeTest/perfume-grid.tsx
+++ b/CHICCHIC/src/components/PersonalPerfumeTest/perfume-grid.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { PerfumeCard } from './perfume-card';
 import type { Perfume } from '../../types/perfumes';
-import { axiosInstance } from '../../apis/axiosInstance';
 
 // API 응답에 대한 타입 정의
 interface ApiPerfume {
@@ -21,10 +20,17 @@ export function PerfumeGrid() {
   useEffect(() => {
     const fetchPopularPerfumes = async () => {
       try {
-        const response = await axiosInstance.get('/api/v1/perfumes/popular');
+        const response = await fetch(
+          'https://be-chicchicenvironments.up.railway.app/home/popular-products',
+        );
+        if (!response.ok) {
+          console.error('API 요청 실패:', response);
+          throw new Error(`향수 정보를 불러오는데 실패했습니다. (상태 코드: ${response.status})`);
+        }
+        const data = await response.json();
 
         // API 응답이 객체이고 result 속성에 배열이 담겨있습니다.
-        const perfumeList: ApiPerfume[] = response.data.result;
+        const perfumeList: ApiPerfume[] = data.result;
 
         if (!Array.isArray(perfumeList)) {
           throw new Error('API 응답 형식이 올바르지 않습니다 (배열이 아님).');

--- a/CHICCHIC/src/components/skeletons/LayoutSkeleton.tsx
+++ b/CHICCHIC/src/components/skeletons/LayoutSkeleton.tsx
@@ -1,0 +1,72 @@
+import { memo } from "react";
+
+interface LayoutSkeletonProps {
+  variant?: 'full' | 'content' | 'card';
+}
+
+const LayoutSkeleton = memo(({ variant = 'full' }: LayoutSkeletonProps) => {
+  if (variant === 'card') {
+    return (
+      <div className="bg-white rounded-lg p-6 shadow-sm animate-pulse">
+        <div className="w-full h-40 bg-gray-200 rounded mb-4"></div>
+        <div className="w-3/4 h-4 bg-gray-200 rounded mb-2"></div>
+        <div className="w-1/2 h-4 bg-gray-200 rounded"></div>
+      </div>
+    );
+  }
+
+  if (variant === 'content') {
+    return (
+      <div className="max-w-7xl mx-auto p-6">
+        <div className="w-48 h-8 bg-gray-200 rounded animate-pulse mb-6"></div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <LayoutSkeleton key={index} variant="card" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#F7F4EF] min-h-screen flex flex-col">
+      {/* Navbar 스켈레톤 */}
+      <div className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="w-32 h-8 bg-gray-200 rounded animate-pulse"></div>
+            <div className="flex space-x-4">
+              <div className="w-16 h-8 bg-gray-200 rounded animate-pulse"></div>
+              <div className="w-16 h-8 bg-gray-200 rounded animate-pulse"></div>
+              <div className="w-20 h-8 bg-gray-200 rounded animate-pulse"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 메인 컨텐츠 */}
+      <main className="flex-1">
+        <LayoutSkeleton variant="content" />
+      </main>
+
+      {/* Footer 스켈레톤 */}
+      <div className="bg-gray-800 text-white">
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="space-y-3">
+                <div className="w-24 h-4 bg-gray-600 rounded animate-pulse"></div>
+                <div className="w-32 h-4 bg-gray-600 rounded animate-pulse"></div>
+                <div className="w-28 h-4 bg-gray-600 rounded animate-pulse"></div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+LayoutSkeleton.displayName = "LayoutSkeleton";
+
+export default LayoutSkeleton;

--- a/CHICCHIC/src/hooks/useAuth.ts
+++ b/CHICCHIC/src/hooks/useAuth.ts
@@ -1,6 +1,5 @@
-import { useCallback } from "react";
 import { useAuthStore } from "../store/useAuthStore";
-import { clearAuthTokens, getAccessToken, getRefreshToken } from "../utils/authStorage";
+import { getAccessToken, getRefreshToken } from "../utils/authStorage";
 
 export function useAuth() {
   const {
@@ -11,13 +10,7 @@ export function useAuth() {
     setIsRefreshing,
     setIsInitialized,
     login: storeLogin,
-    logout: storeLogout,
   } = useAuthStore();
-  
-  const logout = useCallback(() => {
-    clearAuthTokens(); // 토큰 삭제
-    storeLogout(); // 스토어 상태 초기화
-  }, [storeLogout]);
 
   return {
     // 상태
@@ -28,7 +21,6 @@ export function useAuth() {
     
     // 액션
     login: storeLogin,
-    logout,
     setUser,
     setIsRefreshing,
     setIsInitialized,

--- a/CHICCHIC/src/hooks/useAuth.ts
+++ b/CHICCHIC/src/hooks/useAuth.ts
@@ -1,4 +1,13 @@
+import { useAuthStore } from "../store/useAuthStore";
+import { getAccessToken, getRefreshToken } from "../utils/authStorage";
+
 export function useAuth() {
-  const isLoggedIn = Boolean(localStorage.getItem("accessToken"));
-  return { isLoggedIn };
-} // 전역 상태 관리 추가
+  const isRefreshing = useAuthStore((state) => state.isRefreshing);
+  
+  const accessToken = getAccessToken();
+  const refreshToken = getRefreshToken();
+  
+  const isLoggedIn = !!accessToken || !!refreshToken || isRefreshing;
+  
+  return { isLoggedIn, isRefreshing };
+}

--- a/CHICCHIC/src/hooks/useAuth.ts
+++ b/CHICCHIC/src/hooks/useAuth.ts
@@ -1,13 +1,36 @@
+import { useCallback } from "react";
 import { useAuthStore } from "../store/useAuthStore";
-import { getAccessToken, getRefreshToken } from "../utils/authStorage";
+import { clearAuthTokens, getAccessToken, getRefreshToken } from "../utils/authStorage";
 
 export function useAuth() {
-  const isRefreshing = useAuthStore((state) => state.isRefreshing);
+  const {
+    user,
+    isRefreshing,
+    isInitialized,
+    setUser,
+    setIsRefreshing,
+    setIsInitialized,
+    login: storeLogin,
+    logout: storeLogout,
+  } = useAuthStore();
   
-  const accessToken = getAccessToken();
-  const refreshToken = getRefreshToken();
-  
-  const isLoggedIn = !!accessToken || !!refreshToken || isRefreshing;
-  
-  return { isLoggedIn, isRefreshing };
+  const logout = useCallback(() => {
+    clearAuthTokens(); // 토큰 삭제
+    storeLogout(); // 스토어 상태 초기화
+  }, [storeLogout]);
+
+  return {
+    // 상태
+    user,
+    isRefreshing,
+    isInitialized,
+    isLoggedIn: !!getAccessToken() || !!getRefreshToken() || isRefreshing,
+    
+    // 액션
+    login: storeLogin,
+    logout,
+    setUser,
+    setIsRefreshing,
+    setIsInitialized,
+  };
 }

--- a/CHICCHIC/src/layouts/BaseLayout.tsx
+++ b/CHICCHIC/src/layouts/BaseLayout.tsx
@@ -1,23 +1,40 @@
 import { Outlet, useLocation, Navigate } from "react-router-dom";
+import { memo, useMemo, Suspense } from "react";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import CommunityTabBar from "../components/Community/CommunityTabBar";
 import ScrollTop from "../components/ScrollTop";
 import { useAuth } from "../hooks/useAuth";
+import LoadingSkeleton from "../components/skeletons/LayoutSkeleton";
 
 interface BaseLayoutProps {
   protectedRoute?: boolean;
 }
 
-const BaseLayout = ({ protectedRoute = false }: BaseLayoutProps) => {
-  const { isLoggedIn } = useAuth();
+const BaseLayout = memo(({ protectedRoute = false }: BaseLayoutProps) => {
+  const { isLoggedIn, isRefreshing } = useAuth();
   const location = useLocation();
-  const isCommunityPage = location.pathname.startsWith("/community");
 
-  if (protectedRoute && !isLoggedIn) {
-    // 로그인 안 되어 있으면 로그인 페이지로 리디렉션
-    return <Navigate to="/login" state={{ from: location }} replace />;
-  }
+  const isCommunityPage = useMemo(
+    () => location.pathname.startsWith("/community"),
+    [location.pathname]
+  );
+
+  const authGuard = useMemo(() => {
+    if (!protectedRoute) return null;
+
+    if (isRefreshing) {
+      return <LoadingSkeleton />;
+    }
+
+    if (!isLoggedIn) {
+      return <Navigate to="/login" state={{ from: location }} replace />;
+    }
+
+    return null;
+  }, [protectedRoute, isRefreshing, isLoggedIn, location]);
+
+  if (authGuard) return authGuard;
 
   return (
     <div className="bg-[#F7F4EF] min-h-screen flex flex-col">
@@ -25,11 +42,15 @@ const BaseLayout = ({ protectedRoute = false }: BaseLayoutProps) => {
       <Navbar />
       {isCommunityPage && <CommunityTabBar />}
       <main className="flex-1">
-        <Outlet />
+        <Suspense fallback={<LoadingSkeleton />}>
+          <Outlet />
+        </Suspense>
       </main>
       <Footer />
     </div>
   );
-};
+});
+
+BaseLayout.displayName = "BaseLayout";
 
 export default BaseLayout;

--- a/CHICCHIC/src/pages/Mypage/MyScraps.tsx
+++ b/CHICCHIC/src/pages/Mypage/MyScraps.tsx
@@ -93,7 +93,7 @@ const MyScraps = () => {
             {scraps.map((perfume, index) => (
               <div 
                 key={`${perfume.id}-${index}`} 
-                className="overflow-hidden cursor-pointer transition-transform duration-200 hover:scale-102"
+                className="overflow-hidden"
                 onClick={() => handleProductClick(perfume.id)}
               >
                 {/* 이미지 */}
@@ -101,7 +101,7 @@ const MyScraps = () => {
                   <img
                     src={perfume.imageUrl}
                     alt={perfume.name}
-                    className="relative aspect-[4/5] w-full overflow-hidden mb-4 bg-gray-200"
+                    className="relative aspect-[4/5] w-full overflow-hidden mb-4 bg-gray-200 transition-transform duration-200 hover:scale-103"
                     onError={(e) => {
                       e.currentTarget.src = "https://dummyimage.com/300x400/ccc/fff&text=No+Image";
                     }}
@@ -122,7 +122,6 @@ const MyScraps = () => {
         )}
       </div>
 
-      {/* 페이지네이션 - 스크랩이 있을 때만 표시 */}
       {!isLoading && scraps.length > 0 && totalPages > 1 && (
         <div className="flex justify-center items-center py-12 space-x-4">
           {/* 이전 페이지 버튼 */}

--- a/CHICCHIC/src/pages/Mypage/MyScraps.tsx
+++ b/CHICCHIC/src/pages/Mypage/MyScraps.tsx
@@ -1,748 +1,66 @@
 import { useState, useEffect } from 'react';
 import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
-import SamplePerfumeImg from "../../assets/images/samplePerfumeImg.png";
-
-interface Perfume {
-  id: number;
-  name: string;
-  brand: string;
-  imageUrl: string;
-  price: string;
-  volume: string;
-}
-
-// 임시(api 연동 전)
-const MOCK_SCRAPS: Perfume[] = [
-    {
-    id: 1,
-    name: "탐다오",
-    brand: "딥디크",
-    price: "138,000 ₩",
-    volume: "75ml",
-    imageUrl: SamplePerfumeImg,
-  },
-  {
-    id: 2,
-    name: "랑방 에끌라드",
-    brand: "랑방",
-    price: "85,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=랑방",
-  },
-  {
-    id: 3,
-    name: "샤넬 No.5",
-    brand: "샤넬",
-    price: "180,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=샤넬",
-  },
-  {
-    id: 4,
-    name: "미스 디올",
-    brand: "디올",
-    price: "150,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=디올",
-  },
-  {
-    id: 5,
-    name: "톰포드 블랙 오키드",
-    brand: "톰포드",
-    price: "220,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=톰포드",
-  },
-  {
-    id: 6,
-    name: "조 말론 라임 바질",
-    brand: "조 말론",
-    price: "120,000 ₩",
-    volume: "30ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=조말론",
-  },
-  {
-    id: 7,
-    name: "이솝 타시트",
-    brand: "이솝",
-    price: "95,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=이솝",
-  },
-  {
-    id: 8,
-    name: "버버리 허",
-    brand: "버버리",
-    price: "110,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=버버리",
-  },
-  {
-    id: 9,
-    name: "크리드 아벤투스",
-    brand: "크리드",
-    price: "350,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=크리드",
-  },
-  {
-    id: 10,
-    name: "메종 마르지엘라",
-    brand: "마르지엘라",
-    price: "140,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=마르지엘라",
-  },
-  {
-    id: 11,
-    name: "르 라보 로즈",
-    brand: "르 라보",
-    price: "160,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=르라보",
-  },
-  {
-    id: 12,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 13,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 14,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 15,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 16,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 17,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 18,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 19,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 20,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 21,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 22,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 1,
-    name: "탐다오",
-    brand: "딥디크",
-    price: "138,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=탐다오",
-  },
-  {
-    id: 2,
-    name: "랑방 에끌라드",
-    brand: "랑방",
-    price: "85,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=랑방",
-  },
-  {
-    id: 3,
-    name: "샤넬 No.5",
-    brand: "샤넬",
-    price: "180,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=샤넬",
-  },
-  {
-    id: 4,
-    name: "미스 디올",
-    brand: "디올",
-    price: "150,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=디올",
-  },
-  {
-    id: 5,
-    name: "톰포드 블랙 오키드",
-    brand: "톰포드",
-    price: "220,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=톰포드",
-  },
-  {
-    id: 6,
-    name: "조 말론 라임 바질",
-    brand: "조 말론",
-    price: "120,000 ₩",
-    volume: "30ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=조말론",
-  },
-  {
-    id: 7,
-    name: "이솝 타시트",
-    brand: "이솝",
-    price: "95,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=이솝",
-  },
-  {
-    id: 8,
-    name: "버버리 허",
-    brand: "버버리",
-    price: "110,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=버버리",
-  },
-  {
-    id: 9,
-    name: "크리드 아벤투스",
-    brand: "크리드",
-    price: "350,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=크리드",
-  },
-  {
-    id: 10,
-    name: "메종 마르지엘라",
-    brand: "마르지엘라",
-    price: "140,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=마르지엘라",
-  },
-  {
-    id: 11,
-    name: "르 라보 로즈",
-    brand: "르 라보",
-    price: "160,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=르라보",
-  },
-  {
-    id: 12,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 13,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 14,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 15,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 16,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 17,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 18,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 19,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 20,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 21,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 22,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 1,
-    name: "탐다오",
-    brand: "딥디크",
-    price: "138,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=탐다오",
-  },
-  {
-    id: 2,
-    name: "랑방 에끌라드",
-    brand: "랑방",
-    price: "85,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=랑방",
-  },
-  {
-    id: 3,
-    name: "샤넬 No.5",
-    brand: "샤넬",
-    price: "180,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=샤넬",
-  },
-  {
-    id: 4,
-    name: "미스 디올",
-    brand: "디올",
-    price: "150,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=디올",
-  },
-  {
-    id: 5,
-    name: "톰포드 블랙 오키드",
-    brand: "톰포드",
-    price: "220,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=톰포드",
-  },
-  {
-    id: 6,
-    name: "조 말론 라임 바질",
-    brand: "조 말론",
-    price: "120,000 ₩",
-    volume: "30ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=조말론",
-  },
-  {
-    id: 7,
-    name: "이솝 타시트",
-    brand: "이솝",
-    price: "95,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=이솝",
-  },
-  {
-    id: 8,
-    name: "버버리 허",
-    brand: "버버리",
-    price: "110,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=버버리",
-  },
-  {
-    id: 9,
-    name: "크리드 아벤투스",
-    brand: "크리드",
-    price: "350,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=크리드",
-  },
-  {
-    id: 10,
-    name: "메종 마르지엘라",
-    brand: "마르지엘라",
-    price: "140,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=마르지엘라",
-  },
-  {
-    id: 11,
-    name: "르 라보 로즈",
-    brand: "르 라보",
-    price: "160,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=르라보",
-  },
-  {
-    id: 12,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 13,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 14,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 15,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 16,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 17,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 18,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 19,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 20,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 21,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 22,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 1,
-    name: "탐다오",
-    brand: "딥디크",
-    price: "138,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=탐다오",
-  },
-  {
-    id: 2,
-    name: "랑방 에끌라드",
-    brand: "랑방",
-    price: "85,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=랑방",
-  },
-  {
-    id: 3,
-    name: "샤넬 No.5",
-    brand: "샤넬",
-    price: "180,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=샤넬",
-  },
-  {
-    id: 4,
-    name: "미스 디올",
-    brand: "디올",
-    price: "150,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=디올",
-  },
-  {
-    id: 5,
-    name: "톰포드 블랙 오키드",
-    brand: "톰포드",
-    price: "220,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=톰포드",
-  },
-  {
-    id: 6,
-    name: "조 말론 라임 바질",
-    brand: "조 말론",
-    price: "120,000 ₩",
-    volume: "30ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=조말론",
-  },
-  {
-    id: 7,
-    name: "이솝 타시트",
-    brand: "이솝",
-    price: "95,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=이솝",
-  },
-  {
-    id: 8,
-    name: "버버리 허",
-    brand: "버버리",
-    price: "110,000 ₩",
-    volume: "75ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=버버리",
-  },
-  {
-    id: 9,
-    name: "크리드 아벤투스",
-    brand: "크리드",
-    price: "350,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=크리드",
-  },
-  {
-    id: 10,
-    name: "메종 마르지엘라",
-    brand: "마르지엘라",
-    price: "140,000 ₩",
-    volume: "100ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=마르지엘라",
-  },
-  {
-    id: 11,
-    name: "르 라보 로즈",
-    brand: "르 라보",
-    price: "160,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=르라보",
-  },
-  {
-    id: 12,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 13,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 14,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 15,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 16,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 17,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 18,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 19,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 20,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 21,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-  {
-    id: 22,
-    name: "바이레도 블랑쉬",
-    brand: "바이레도",
-    price: "145,000 ₩",
-    volume: "50ml",
-    imageUrl: "https://dummyimage.com/300x300/ccc/fff&text=바이레도",
-  },
-];
+import { useNavigate } from 'react-router-dom';
+import { getScrapList } from '../../apis/products';
+import type { Scrap } from '../../types/perfumes';
 
 const itemsPerPage = 16;
 
 const MyScraps = () => {
-  const [scraps, setScraps] = useState<Perfume[]>([]);
+  const [scraps, setScraps] = useState<Scrap[]>([]);
+  const [allScraps, setAllScraps] = useState<Scrap[]>([]);
   const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const totalPages = Math.ceil(MOCK_SCRAPS.length / itemsPerPage);
+  const navigate = useNavigate();
+
+  // 페이지네이션 전체 데이터 기준
+  const totalPages = Math.ceil(allScraps.length / itemsPerPage);
   const pageGroupSize = 5;
   const currentGroup = Math.ceil(page / pageGroupSize);
   
   const startPage = (currentGroup - 1) * pageGroupSize + 1;
   const endPage = Math.min(currentGroup * pageGroupSize, totalPages);
 
+  const fetchScraps = async () => {
+    try {
+      setIsLoading(true);
+      const response = await getScrapList();
+      
+      if (response.isSuccess) {
+        setAllScraps(response.result);
+      } else {
+        console.error('스크랩 목록 조회 실패:', response.message);
+        setAllScraps([]);
+      }
+    } catch (error) {
+      console.error('스크랩 목록 조회 에러:', error);
+      setAllScraps([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleProductClick = (productId: number) => {
+    navigate(`/shopping/${productId}`);
+  };
+
   useEffect(() => {
-    // axios 연동
-    // 임시 데이터
+    fetchScraps();
+  }, []);
+
+  useEffect(() => {
     const start = (page - 1) * itemsPerPage;
     const end = start + itemsPerPage;
-    setScraps(MOCK_SCRAPS.slice(start, end));
-  }, [page]);
+    setScraps(allScraps.slice(start, end));
+  }, [page, allScraps]);
+
+  const formatPrice = (price: number) => {
+    return `${price.toLocaleString()} ₩`;
+  };
 
   return (
-    <div className="min-h-screen bg-[#66191F] pt-10 pb-20 text-[#F7F4EF] px-3 sm:px-3">
-
+    <div className="min-h-screen bg-[#66191F] pt-15 pb-20 text-[#F7F4EF] px-3 sm:px-3">
       <div className="text-center mb-13 mt-13">
         <h2 className="text-5xl mb-8">MY SCRAP</h2>
         <div className="w-15 h-px bg-[#F7F4EF] mx-auto mb-7 opacity-50"></div>
@@ -752,31 +70,51 @@ const MyScraps = () => {
       </div>
 
       <div className="w-full max-w-screen-2xl mx-auto">
-        {scraps.length === 0 ? (
+        {isLoading ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {Array.from({ length: 8 }).map((_, index) => (
+              <div key={index} className="overflow-hidden">
+                <div className="relative aspect-[4/5] w-full overflow-hidden mb-4 bg-gray-200 animate-pulse"></div>
+                <div className="p-2 pt-4 pb-6">
+                  <div className="h-5 bg-gray-300 animate-pulse mb-2 rounded"></div>
+                  <div className="h-6 bg-gray-300 animate-pulse mb-2 rounded"></div>
+                  <div className="h-5 bg-gray-300 animate-pulse rounded"></div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : scraps.length === 0 ? (
           <div className="text-center py-20">
             <p className="text-xl text-[#F7F4EF] opacity-70 mb-4">아직 스크랩한 향수가 없습니다.</p>
             <p className="text-base text-[#F7F4EF] opacity-50">마음에 드는 향수를 스크랩해보세요!</p>
-          </div> // api 연동 후 수정
+          </div>
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
             {scraps.map((perfume, index) => (
-              <div key={`${perfume.id}-${index}`} className="overflow-hidden cursor-pointer">
+              <div 
+                key={`${perfume.id}-${index}`} 
+                className="overflow-hidden cursor-pointer transition-transform duration-200 hover:scale-102"
+                onClick={() => handleProductClick(perfume.id)}
+              >
                 {/* 이미지 */}
                 <div className="aspect-[4/5] w-full overflow-hidden bg-[#F7F4EF]">
                   <img
                     src={perfume.imageUrl}
                     alt={perfume.name}
-                    className="w-full h-full object-contain transition-transform duration-300 hover:scale-110 active:scale-105"
+                    className="relative aspect-[4/5] w-full overflow-hidden mb-4 bg-gray-200"
+                    onError={(e) => {
+                      e.currentTarget.src = "https://dummyimage.com/300x400/ccc/fff&text=No+Image";
+                    }}
                   />
                 </div>
                 {/* 텍스트 */}
-                <div className="p-2 pt-4 pb-6 text-left">
+                <div className="p-2 pt-4 pb-5 text-left">
                   <div className="text-lg mb-1 font-extralight">{perfume.brand}</div>
                   <div className="sm:flex sm:justify-between">
-                    <div className="text-2xl font-semibold mb-2">{perfume.name}</div>
-                    <div className="text-lg font-extralight">{perfume.volume}</div>
+                    <div className="text-2xl font-semibold mb-2 line-clamp-2">{perfume.name}</div>
+                    <div className="text-lg font-extralight">{perfume.ml}ml</div>
                   </div>
-                  <div className="text-lg font-extralight">{perfume.price}</div>
+                  <div className="text-lg font-extralight mt-2">{formatPrice(perfume.price)}</div>
                 </div>
               </div>
             ))}
@@ -785,7 +123,7 @@ const MyScraps = () => {
       </div>
 
       {/* 페이지네이션 - 스크랩이 있을 때만 표시 */}
-      {scraps.length > 0 && totalPages > 1 && (
+      {!isLoading && scraps.length > 0 && totalPages > 1 && (
         <div className="flex justify-center items-center py-12 space-x-4">
           {/* 이전 페이지 버튼 */}
           <button

--- a/CHICCHIC/src/pages/Mypage/Privacy.tsx
+++ b/CHICCHIC/src/pages/Mypage/Privacy.tsx
@@ -32,7 +32,7 @@ const Privacy = () => {
     phone: '',
     email: '',
   });
-  const [error, setError] = useState<string | null>(null);
+
   const [saving, setSaving] = useState(false);
 
   const [isResetToDefault, setIsResetToDefault] = useState(false);
@@ -66,7 +66,9 @@ const Privacy = () => {
             email: userData.email || '',
           });
         })
-        .catch(() => {
+        .catch((err) => {
+          console.error("사용자 정보 조회 실패:", err);
+          alert("사용자 정보를 불러오는데 실패했습니다.");
           setFormData({
             nickname: '',
             phone: '',
@@ -121,7 +123,6 @@ const Privacy = () => {
   };
 
   const handleSaveClick = async () => {
-    setError(null);
     setSaving(true);
     try {
       // 사용자 정보 업데이트
@@ -142,18 +143,24 @@ const Privacy = () => {
           await deleteProfileImage();
           setProfileImage(DEFAULT_PROFILE_IMAGE);
         } catch (error) {
-          console.error("프로필 이미지 삭제 실패:", error);
+          console.error("기본 프로필 적용 실패:", error);
+          alert("기본 프로필 적용에 실패했습니다.");
           setProfileImage(DEFAULT_PROFILE_IMAGE);
         }
         setIsProfileImageLoading(false);
       } else if (file) {
         setIsProfileImageLoading(true);
-        const fd = new FormData();
-        fd.append("file", file);
-        const res = await putProfileImage(fd);
+        try {
+          const fd = new FormData();
+          fd.append("file", file);
+          const res = await putProfileImage(fd);
 
-        const newUrl = `${res.data.result}?v=${Date.now()}`;
-        setProfileImage(newUrl);
+          const newUrl = `${res.data.result}?v=${Date.now()}`;
+          setProfileImage(newUrl);
+        } catch (error) {
+          console.error("프로필 이미지 업로드 실패:", error);
+          alert("프로필 이미지 업로드에 실패했습니다.");
+        }
         setIsProfileImageLoading(false);
       }
 
@@ -162,7 +169,8 @@ const Privacy = () => {
       setIsEditing(false);
       
     } catch (err) {
-      setError("회원정보 수정에 실패했습니다.");
+      console.error("회원정보 수정 실패:", err);
+      alert("회원정보 수정에 실패했습니다. 다시 시도해주세요.");
       setIsProfileImageLoading(false);
     } finally {
       setSaving(false);
@@ -181,7 +189,8 @@ const Privacy = () => {
       alert("회원 탈퇴가 완료되었습니다.");
       navigate("/");
     } catch (err) {
-      setError("회원 탈퇴에 실패했습니다.");
+      console.error("회원 탈퇴 실패:", err);
+      alert("회원 탈퇴에 실패했습니다. 다시 시도해주세요.");
     }
   };
 
@@ -246,7 +255,7 @@ const Privacy = () => {
           <PrivacySkeleton />
         ) : (
           <>
-            <div className="flex flex-row gap-10 items-center mb-13">
+            <div className="flex flex-row gap-10 items-center mb-10">
               <div className="relative w-32 h-32 mb-4">
                 <div 
                   className="w-32 h-32 rounded-full bg-gray-400 flex items-center justify-center cursor-pointer hover:bg-gray-500 transition-colors relative overflow-hidden"
@@ -367,10 +376,6 @@ const Privacy = () => {
               </div>
             </div>
           </>
-        )}
-        
-        {error && (
-          <div className="text-sm text-red-500 mt-2">{error}</div>
         )}
       </main>
     </div>

--- a/CHICCHIC/src/pages/Mypage/Profile.tsx
+++ b/CHICCHIC/src/pages/Mypage/Profile.tsx
@@ -102,7 +102,7 @@ export default function MyHome() {
         </ul>
       </div>
       <main className="flex-1 flex flex-col items-center justify-start pt-16 px-8 sm:items-start sm:ml-20">
-        <div className="w-55 h-55 rounded-full flex items-center justify-center mb-6 mt-20 overflow-hidden">
+        <div className="w-55 h-55 rounded-full flex items-center justify-center mb-6 mt-10 overflow-hidden">
           {isProfileImageLoading ? (
             <div className="w-full h-full object-cover rounded-full bg-gray-200 animate-pulse" />
           ) : (

--- a/CHICCHIC/src/pages/Mypage/Profile.tsx
+++ b/CHICCHIC/src/pages/Mypage/Profile.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from "../../store/useAuthStore";
 
 const DEFAULT_PROFILE_IMAGE = "https://aws-chicchic-bucket.s3.ap-northeast-2.amazonaws.com/default-profile.png";
 
-export default function MyHome() {
+export default function Profile() {
   const location = useLocation();
   const navigate = useNavigate();
   const currentPath = location.pathname;
@@ -59,11 +59,11 @@ export default function MyHome() {
         setIsProfileImageLoading(false);
       });
   }, [user, setUser]);
-  
-  if (!isLoggedIn()) {
-    navigate("/login");
-    return null;
-  }
+
+if (!isLoggedIn()) {
+  return null; // 이동 전까지 화면에 아무것도 안 보이게
+}
+
 
   const handleProfileClick = () => navigate("/mypage");
   const handlePrivacyClick = () => navigate("/mypage/privacy");

--- a/CHICCHIC/src/pages/Mypage/Profile.tsx
+++ b/CHICCHIC/src/pages/Mypage/Profile.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { useLogout } from "../../utils/useLogout";
 import { getUserInfo, getProfileImage } from "../../apis/auth";
+import { useAuthStore } from "../../store/useAuthStore";
 
 const DEFAULT_PROFILE_IMAGE = "https://aws-chicchic-bucket.s3.ap-northeast-2.amazonaws.com/default-profile.png";
 
@@ -11,24 +12,41 @@ export default function MyHome() {
   const currentPath = location.pathname;
   const logout = useLogout();
 
-  const [userNickname, setUserNickname] = useState("(닉네임)");
-  const [isLoading, setIsLoading] = useState(true);
+  // zustand 전역 상태 사용
+  const { user, setUser, isLoggedIn } = useAuthStore();
+
+  const [isUserInfoLoading, setIsUserInfoLoading] = useState(true);
+  const [isProfileImageLoading, setIsProfileImageLoading] = useState(true);
   const [profileImage, setProfileImage] = useState<string>(DEFAULT_PROFILE_IMAGE);
 
+  // 전역 상태에서 닉네임 가져오기
+  const userNickname = user?.nickname || "(닉네임)";
+
   useEffect(() => {
-    getUserInfo()
-      .then((res) => {
-        if (res.data?.result?.nickname) {
-          setUserNickname(res.data.result.nickname);
-        }
-      })
-      .catch(() => {
-        setUserNickname("(닉네임)");
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-      
+    if (!user || !user.nickname) {
+      getUserInfo()
+        .then((res) => {
+          if (res.data?.result) {
+            const userData = res.data.result;
+            setUser({
+              email: userData.email,
+              phoneNumber: userData.phoneNumber || "",
+              nickname: userData.nickname,
+            });
+          }
+        })
+        .catch(() => {
+          console.error("사용자 정보를 불러올 수 없습니다.");
+        })
+        .finally(() => {
+          setIsUserInfoLoading(false);
+        });
+    } else {
+      setIsUserInfoLoading(false);
+    }
+
+    // 프로필 이미지는 별도의 api에서 처리하기 때문에 따로
+    setIsProfileImageLoading(true);
     getProfileImage()
       .then((res) => {
         const url = res.data.result;
@@ -36,8 +54,16 @@ export default function MyHome() {
       })
       .catch(() => {
         setProfileImage(DEFAULT_PROFILE_IMAGE);
+      })
+      .finally(() => {
+        setIsProfileImageLoading(false);
       });
-  }, []);
+  }, [user, setUser]);
+  
+  if (!isLoggedIn()) {
+    navigate("/login");
+    return null;
+  }
 
   const handleProfileClick = () => navigate("/mypage");
   const handlePrivacyClick = () => navigate("/mypage/privacy");
@@ -75,24 +101,21 @@ export default function MyHome() {
           </li>
         </ul>
       </div>
-
-      {/* 내용 영역 */}
       <main className="flex-1 flex flex-col items-center justify-start pt-16 px-8 sm:items-start sm:ml-20">
-        {/* 프로필 이미지 */}
         <div className="w-55 h-55 rounded-full flex items-center justify-center mb-6 mt-20 overflow-hidden">
-          {isLoading ? (
+          {isProfileImageLoading ? (
             <div className="w-full h-full object-cover rounded-full bg-gray-200 animate-pulse" />
           ) : (
             <img
-            src={profileImage}
-            alt="Profile"
-            className="w-full h-full object-cover rounded-full"/>
+              src={profileImage} 
+              alt="Profile"
+              className="w-full h-full object-cover rounded-full"
+            />
           )}
         </div>
 
-        {/* 닉네임 영역 + Skeleton UI */}
         <div className="text-3xl mt-5 font-semibold mb-2 text-center sm:text-left">
-          {isLoading ? (
+          {isUserInfoLoading ? (
             <div className="w-60 h-10 bg-gray-200 animate-pulse rounded-md" />
           ) : (
             `안녕하세요, ${userNickname}님!`

--- a/CHICCHIC/src/pages/SignUp.tsx
+++ b/CHICCHIC/src/pages/SignUp.tsx
@@ -86,6 +86,18 @@ export default function Signup() {
       if (axios.isAxiosError(err)) {
         const resData = err.response?.data;
 
+        if (
+          resData?.result &&
+          typeof resData.result === "string" &&
+          resData.result.includes("Duplicate entry") &&
+          resData.result.includes("nickname")
+        ) {
+          setFieldErrors({
+            nickname: "이미 사용 중인 닉네임입니다.",
+          });
+          return;
+        }
+
         // 필드별 에러
         if (resData?.result) {
           const errors = resData.result;

--- a/CHICCHIC/src/store/useAuthStore.ts
+++ b/CHICCHIC/src/store/useAuthStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+interface AuthState {
+  isRefreshing: boolean;
+  setIsRefreshing: (value: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isRefreshing: false,
+  
+  setIsRefreshing: (value: boolean) => set({ isRefreshing: value }),
+}));

--- a/CHICCHIC/src/store/useAuthStore.ts
+++ b/CHICCHIC/src/store/useAuthStore.ts
@@ -1,12 +1,45 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { getAccessToken, getRefreshToken } from "../utils/authStorage";
+import type { UserInfo } from "../types/authtypes";
 
 interface AuthState {
+  user: UserInfo | null;
+  isInitialized: boolean;
   isRefreshing: boolean;
+  setUser: (user: UserInfo | null) => void;
+  setIsInitialized: (value: boolean) => void;
   setIsRefreshing: (value: boolean) => void;
+  login: (user: UserInfo) => void;
+  logout: () => void;
+  isLoggedIn: () => boolean;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  isRefreshing: false,
-  
-  setIsRefreshing: (value: boolean) => set({ isRefreshing: value }),
-}));
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      isInitialized: false,
+      isRefreshing: false,
+
+      setUser: (user) => set({ user }),
+      setIsInitialized: (value) => set({ isInitialized: value }),
+      setIsRefreshing: (value) => set({ isRefreshing: value }),
+
+      login: (user) => set({ user, isInitialized: true }),
+      logout: () => set({ user: null, isRefreshing: false }),
+
+      isLoggedIn: () => {
+        const { user, isRefreshing } = get();
+        return !!user && (!!getAccessToken() || !!getRefreshToken() || isRefreshing);
+      },
+    }),
+    {
+      name: 'auth-storage',
+      partialize: (state) => ({
+        user: state.user,
+        isInitialized: state.isInitialized
+      }),
+    }
+  )
+);

--- a/CHICCHIC/src/types/perfumes.ts
+++ b/CHICCHIC/src/types/perfumes.ts
@@ -41,10 +41,14 @@ export type Scrap = {
   concentration: string;
   price: number;
   itemRating: number;
+  imageUrl: string;
 };
 
 // 스크랩 추가 및 삭제 응답
 export type ResponseScrapDto = CommonResponse<"">;
+
+// 스크랩 조회 응답
+export type ResponseScrapListDto = CommonResponse<Scrap[]>;
 
 // 상품 리뷰 삭제 응답
 export type ResponseDeleteReviewDto = CommonResponse<Record<string, never>>;

--- a/CHICCHIC/src/utils/authStorage.ts
+++ b/CHICCHIC/src/utils/authStorage.ts
@@ -1,29 +1,67 @@
 import { LOCAL_STORAGE_KEY } from "../constants/key";
 
-// accessToken
-export const getAccessToken = (): string | null =>
-  localStorage.getItem(LOCAL_STORAGE_KEY.accessToken);
+// rememberMe 상태 관리
+export const getRememberMe = (): boolean => {
+  return localStorage.getItem("rememberMe") === "true";
+};
 
-export const setAccessToken = (token: string): void =>
-  localStorage.setItem(LOCAL_STORAGE_KEY.accessToken, token);
+export const setRememberMe = (remember: boolean): void => {
+  localStorage.setItem("rememberMe", String(remember));
+};
+
+export const getAccessToken = (): string | null => {
+  // localStorage 우선 확인, 없으면 sessionStorage 확인
+  return localStorage.getItem(LOCAL_STORAGE_KEY.accessToken) ||
+         sessionStorage.getItem(LOCAL_STORAGE_KEY.accessToken);
+};
+
+export const setAccessToken = (token: string, rememberMe: boolean = getRememberMe()): void => {
+  if (rememberMe) {
+    localStorage.setItem(LOCAL_STORAGE_KEY.accessToken, token);
+    sessionStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+  } else {
+    sessionStorage.setItem(LOCAL_STORAGE_KEY.accessToken, token);
+    localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+  }
+};
 
 export const removeAccessToken = (): void => {
   localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+  sessionStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
 };
 
-// refreshToken
-export const getRefreshToken = (): string | null =>
-  localStorage.getItem(LOCAL_STORAGE_KEY.refreshToken);
+export const getRefreshToken = (): string | null => {
+  return localStorage.getItem(LOCAL_STORAGE_KEY.refreshToken) ||
+         sessionStorage.getItem(LOCAL_STORAGE_KEY.refreshToken);
+};
 
-export const setRefreshToken = (token: string): void =>
-  localStorage.setItem(LOCAL_STORAGE_KEY.refreshToken, token);
+export const setRefreshToken = (token: string, rememberMe: boolean = getRememberMe()): void => {
+  if (rememberMe) {
+    localStorage.setItem(LOCAL_STORAGE_KEY.refreshToken, token);
+    sessionStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
+  } else {
+    sessionStorage.setItem(LOCAL_STORAGE_KEY.refreshToken, token);
+    localStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
+  }
+};
 
 export const removeRefreshToken = (): void => {
   localStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
+  sessionStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
 };
 
-// 둘 다 삭제 (로그아웃)
 export const clearAuthTokens = (): void => {
-  localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
-  localStorage.removeItem(LOCAL_STORAGE_KEY.refreshToken);
+  removeAccessToken();
+  removeRefreshToken();
+  localStorage.removeItem("rememberMe");
+};
+
+export const saveAuthTokens = (
+  accessToken: string,
+  refreshToken: string,
+  rememberMe: boolean
+): void => {
+  setRememberMe(rememberMe);
+  setAccessToken(accessToken, rememberMe);
+  setRefreshToken(refreshToken, rememberMe);
 };

--- a/CHICCHIC/src/utils/useLogout.ts
+++ b/CHICCHIC/src/utils/useLogout.ts
@@ -1,13 +1,15 @@
 import { useNavigate } from "react-router-dom";
 import { clearAuthTokens } from "./authStorage";
+import { useAuthStore } from "../store/useAuthStore";
 
 export const useLogout = () => {
   const navigate = useNavigate();
+  const { logout: storeLogout } = useAuthStore();
 
   const logout = () => {
-    clearAuthTokens();      // 로컬스토리지 토큰 삭제
-    // zustand 전역 상태 초기화 추가해야 됨
-    navigate("/login");
+    clearAuthTokens(); 
+    storeLogout();
+    navigate("/");
   };
 
   return logout;


### PR DESCRIPTION
## #️⃣연관된 이슈

📝작업 내용
- 스크랩 페이지 조회 api 연동
<img width="1905" height="969" alt="스크린샷 2025-08-15 032753" src="https://github.com/user-attachments/assets/ba18282b-eb3c-4801-97fb-6b62192d7c4e" />

- access 토큰 만료 시 refresh 토큰으로 access 토큰 다시 재발급 => 로그인 상태 유지
- 로그인 시 로그인 상태 유지 체크 여부에 따라 체크하면(브라우저 나가도 자동로그인) 로컬 스토리지, 체크 안 하면(브라우저 나가면 로그아웃) 세션 스토리지에 토큰 저장 분기

- 프로필 이미지 초기화 api 연동

- zustand 사용하여 useAuthStore + useAuth에서 사용자 정보 및 전역 상태 관리(토큰은 authStorage에서 따로 관리)

- isLoggedIn: () => {
  const { user, isRefreshing } = get();
  // 사용자 정보 + (토큰 존재 or 갱신 중)
  return !!user && (!!getAccessToken() || !!getRefreshToken() || isRefreshing);
}
// user 정보와 토큰 상태를 모두 확인 => isRefreshing 상태 활용하여 토큰 갱신 중 라우팅 문제(ProtectedLayout 먼저 적용돼서 갱신하기 전에 login 페이지로 이동 문제) 해결

-BaseLayout 리팩토링
BaseLayout 자체를 memo로 감싸서 props(protectedRoute) 변화가 없으면 재렌더링 방지
useMemo(isCommunityPage) - location.pathname이 바뀔 때만 계산
useMemo(authGuard) - 인증 로직도 의존성 변경 시에만 실행
+ Early return + Suspense + 스켈레톤 UI(전체 레이아웃)

스크린샷 (선택)
💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
