### PR TITLE
#78 feat: 쇼핑 카테고리 가격대/발향률 API 연동

### DIFF
--- a/CHICCHIC/src/apis/products.ts
+++ b/CHICCHIC/src/apis/products.ts
@@ -1,4 +1,4 @@
-import type { PostCategory } from "../types/enums/category";
+import type { PerfumeCategory } from "../types/enums/category";
 import type {
   ProductReview,
   RequestProductReviewDto,
@@ -17,7 +17,7 @@ import { axiosInstance } from "./axiosInstance";
 
 // 향수 카테고리 조회 (가격대, 발향률)
 export const getCategories = async (
-  type?: PostCategory
+  type?: PerfumeCategory
 ): Promise<ProductCategory[]> => {
   const { data } = await axiosInstance.get<ProductCategory[]>("/categories", {
     params: type ? { type } : undefined,

--- a/CHICCHIC/src/hooks/queries/useGetProduct.ts
+++ b/CHICCHIC/src/hooks/queries/useGetProduct.ts
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import type { PostCategory } from "../../types/enums/category";
+import type { PerfumeCategory } from "../../types/enums/category";
 import {
   getPerfumeDetail,
   getProductReview,
@@ -14,12 +14,12 @@ import type {
 } from "../../types/products";
 import { QUERY_KEY } from "../../constants/key";
 
-// 향수 상품 카테고리 (노트, 가격대, 발향률)
-export const useGetCategories = (type?: PostCategory) => {
+// 향수 상품 카테고리 (가격대, 발향률)
+export const useGetCategories = (type?: PerfumeCategory) => {
   return useQuery<ProductCategory[], Error>({
     queryKey: [QUERY_KEY.categories, type ?? "ALL"],
     queryFn: () => getCategories(type),
-    staleTime: 5 * 60 * 1000, // 5분
+    staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });
 };

--- a/CHICCHIC/src/types/enums/category.ts
+++ b/CHICCHIC/src/types/enums/category.ts
@@ -2,7 +2,7 @@
 export type PostCategory = "GIVE" | "RECEIVE";
 
 // 향수 카테고리 목록 enum
-export type PerfumeCategory = "PRICE" | "CONCENTRATION";
+export type PerfumeCategory = "NOTE" | "PRICE" | "CONCENTRATION" | null;
 
 // 상품 카테고리
 export type PAGINATION_ORDER =

--- a/CHICCHIC/src/types/products.ts
+++ b/CHICCHIC/src/types/products.ts
@@ -55,7 +55,7 @@ export interface GetProductsParams {
   cat?: number;
 }
 
-// /category 카테고리 목록 조회
+// /category 카테고리 목록 조회 (가격, 발향률)
 export type ProductCategory = {
   categoryId: number;
   name: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

#78 
 
## 📝작업 내용
- 카테고리 /useGetProduct.ts -> useGetCategories훅과 useGetProductList훅을 사용하여 쇼핑 페이지 카테고리 연동

## 스크린샷 (선택)
<img width="751" height="346" alt="스크린샷 2025-08-20 오전 1 33 56" src="https://github.com/user-attachments/assets/85c57507-e600-49da-b242-4c082fc01474" />
<img width="1180" height="775" alt="스크린샷 2025-08-20 오전 1 34 39" src="https://github.com/user-attachments/assets/a2ca963e-d3e2-4fa2-b454-351bcc569eaa" />

💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 현재 백엔드 500에러 있어서 PDT, EDC, Oil 부분은 안됩니다.